### PR TITLE
[#3] Switch to NPM instead of Bower for Excalibur dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - v6
   - v5
-  - v4
 cache:
   directories:
   - node_modules

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, install [Yeoman](http://yeoman.io) and generator-excalibur using [npm](ht
 
 ```bash
 npm install -g yo
-npm install -g generator-excalibur
+npm install -g @excaliburjs/generator-excalibur
 ```
 
 Then generate your new project:

--- a/generators/app/templates/bower.json
+++ b/generators/app/templates/bower.json
@@ -1,8 +1,0 @@
-{
-    "name": "mygame",
-    "version": "0.0.0",
-    "private": true,
-    "dependencies": {
-        "excalibur": "latest"
-    }
-}

--- a/generators/app/templates/game/game.ts
+++ b/generators/app/templates/game/game.ts
@@ -1,4 +1,4 @@
-/// <reference path="../bower_components/excalibur/dist/excalibur.d.ts" />
+/// <reference path="../node_modules/excalibur/dist/excalibur.d.ts" />
 
 var game = new ex.Engine({
     width: 800,

--- a/generators/app/templates/index.html
+++ b/generators/app/templates/index.html
@@ -6,7 +6,7 @@
 <body>
 
     <!-- Excalibur.js reference -->
-    <script src="bower_components/excalibur/dist/excalibur.min.js" type="text/javascript"></script>
+    <script src="node_modules/excalibur/dist/excalibur.min.js" type="text/javascript"></script>
     <!-- Game reference -->
     <script src="game/game.js" type="text/javascript"></script>
 </body>

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -5,6 +5,9 @@
     "scripts": {
         "start": "./node_modules/.bin/tsc -p game/tsconfig.json"
     },
+    "dependencies": {
+        "excalibur": "latest"
+    },
     "devDependencies": {
         "typescript": "latest"
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-excalibur",
+  "name": "@excaliburjs/generator-excalibur",
   "version": "0.3.0",
   "description": "Yeoman generator for Excalibur.js",
   "homepage": "http://excaliburjs.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-excalibur",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Yeoman generator for Excalibur.js",
   "homepage": "http://excaliburjs.com",
   "author": {


### PR DESCRIPTION
Close #3 

Switch to NPM instead of Bower for Excalibur dependency

Additionally Node v4 is no longer supported